### PR TITLE
feat: allow setting main-branch-name via environment variable

### DIFF
--- a/src/scripts/find-successful-workflow.js
+++ b/src/scripts/find-successful-workflow.js
@@ -4,7 +4,7 @@ const https = require('https');
 
 const buildUrl = process.argv[2];
 const branchName = process.argv[3];
-const mainBranchName = process.env.NX_MAIN_BRANCH_NAME || process.argv[4];
+const mainBranchName = process.env.MAIN_BRANCH_NAME || process.argv[4];
 const errorOnNoSuccessfulWorkflow = process.argv[5];
 const workflowName = process.argv[6];
 const circleToken = process.env.CIRCLE_API_TOKEN;

--- a/src/scripts/find-successful-workflow.js
+++ b/src/scripts/find-successful-workflow.js
@@ -4,7 +4,7 @@ const https = require('https');
 
 const buildUrl = process.argv[2];
 const branchName = process.argv[3];
-const mainBranchName = process.argv[4];
+const mainBranchName = process.env.NX_MAIN_BRANCH_NAME || process.argv[4];
 const errorOnNoSuccessfulWorkflow = process.argv[5];
 const workflowName = process.argv[6];
 const circleToken = process.env.CIRCLE_API_TOKEN;


### PR DESCRIPTION
For our CI system we have the concept of multiple main branches. We enabled the "Only build pull requests" option in circleci so that we could reliably determine the base branch based on the PR. However due to a limitation in circle we aren't able to dynamically pass the main branch name after we've computed it from the pull request. As a workaround it would be great if there was a simple environment variable that we could set instead of relying on the circleci parameter to set the main branch name. I'm opening this PR for further discussion. 