### PR TITLE
feat: option to allow on-hold workflows to be detected when deriving …

### DIFF
--- a/src/commands/set-shas.yml
+++ b/src/commands/set-shas.yml
@@ -32,12 +32,13 @@ steps:
         PARAM_MAIN_BRANCH: <<parameters.main-branch-name>>
         PARAM_ERROR_ON_NO_SUCCESSFUL_WORKFLOW: <<parameters.error-on-no-successful-workflow>>
         PARAM_WORKFLOW_NAME: <<parameters.workflow-name>>
+        PARAM_ALLOW_ON_HOLD: <<parameters.allow-on-hold-workflow>>
         PARAM_SCRIPT: <<include(scripts/find-successful-workflow.js)>>
       name: Derives SHAs for base and head for use in `nx affected` commands
       shell: "/bin/bash"
       command: |
         echo "$PARAM_SCRIPT" >> "index.js"
-        RESPONSE=$(node index.js $CIRCLE_BUILD_URL $CIRCLE_BRANCH $PARAM_MAIN_BRANCH $PARAM_ERROR_ON_NO_SUCCESSFUL_WORKFLOW $PARAM_WORKFLOW_NAME)
+        RESPONSE=$(node index.js $CIRCLE_BUILD_URL $CIRCLE_BRANCH $PARAM_MAIN_BRANCH $PARAM_ERROR_ON_NO_SUCCESSFUL_WORKFLOW $PARAM_ALLOW_ON_HOLD $PARAM_WORKFLOW_NAME)
         echo "$RESPONSE"
         BASE_SHA=$(echo "$RESPONSE" | grep 'Commit:' | sed 's/.*Commit: //')
         HEAD_SHA=$(git rev-parse HEAD)

--- a/src/commands/set-shas.yml
+++ b/src/commands/set-shas.yml
@@ -17,8 +17,14 @@ parameters:
     type: string
     default: ""
     description: |
-      By default, the script is looking for the last successful job accross all workflows.
+      By default, the script is looking for the last successful job across all workflows.
       Set this param to search for the last successful job within a specific workflow.
+  allow-on-hold-workflow:
+    type: boolean
+    default: false
+    description: |
+      By default, only workflows with CircleCI status of "success" will be detected for the main branch.
+      Enable this option to also detect workflows with CircleCI status of "on_hold" in case your workflow requires manual approvals.
 
 steps:
   - run:

--- a/src/examples/custom.yml
+++ b/src/examples/custom.yml
@@ -22,6 +22,7 @@ usage:
             main-branch-name: "master" # you can also use the environment variable MAIN_BRANCH_NAME for this purpose
             error-on-no-successful-workflow: true
             workflow-name: "nx-pipeline"
+            allow-on-hold-workflow: true
         - run:
             name: Run Builds
             command: yarn nx affected --target=build --base=$NX_BASE

--- a/src/scripts/find-successful-workflow.js
+++ b/src/scripts/find-successful-workflow.js
@@ -7,6 +7,7 @@ const branchName = process.argv[3];
 const mainBranchName = process.env.MAIN_BRANCH_NAME || process.argv[4];
 const errorOnNoSuccessfulWorkflow = process.argv[5];
 const workflowName = process.argv[6];
+const allowOnHoldWorkflow = process.argv[7];
 const circleToken = process.env.CIRCLE_API_TOKEN;
 
 let BASE_SHA;
@@ -95,10 +96,10 @@ function commitExists(commitSha) {
 async function isWorkflowSuccessful(pipelineId, workflowName) {
   if (!workflowName) {
     return getJson(`https://circleci.com/api/v2/pipeline/${pipelineId}/workflow`)
-      .then(({ items }) => items.every(item => item.status === 'success'));
+      .then(({ items }) => items.every(item => (item.status === 'success') || (allowOnHoldWorkflow === 'true' && item.status === 'on_hold')));
   } else {
     return getJson(`https://circleci.com/api/v2/pipeline/${pipelineId}/workflow`)
-      .then(({ items }) => items.some(item => item.status === 'success' && item.name === workflowName));
+      .then(({ items }) => items.some(item => ((item.status === 'success') || (allowOnHoldWorkflow === 'true' && item.status === 'on_hold')) && item.name === workflowName));
   }
 }
 

--- a/src/scripts/find-successful-workflow.js
+++ b/src/scripts/find-successful-workflow.js
@@ -6,8 +6,8 @@ const buildUrl = process.argv[2];
 const branchName = process.argv[3];
 const mainBranchName = process.env.MAIN_BRANCH_NAME || process.argv[4];
 const errorOnNoSuccessfulWorkflow = process.argv[5];
-const workflowName = process.argv[6];
-const allowOnHoldWorkflow = process.argv[7];
+const allowOnHoldWorkflow = process.argv[6];
+const workflowName = process.argv[7];
 const circleToken = process.env.CIRCLE_API_TOKEN;
 
 let BASE_SHA;


### PR DESCRIPTION
…SHAs

This pull request adds optional support to also check CircleCI workflows that have status "on_hold" when deriving SHAs in order to support approval-based workflows.