### PR TITLE
fix: check for allow-on-hold-workflow param as it will have value 0 o…

### DIFF
--- a/src/scripts/find-successful-workflow.js
+++ b/src/scripts/find-successful-workflow.js
@@ -96,10 +96,10 @@ function commitExists(commitSha) {
 async function isWorkflowSuccessful(pipelineId, workflowName) {
   if (!workflowName) {
     return getJson(`https://circleci.com/api/v2/pipeline/${pipelineId}/workflow`)
-      .then(({ items }) => items.every(item => (item.status === 'success') || (allowOnHoldWorkflow === 'true' && item.status === 'on_hold')));
+      .then(({ items }) => items.every(item => (item.status === 'success') || (allowOnHoldWorkflow === '1' && item.status === 'on_hold')));
   } else {
     return getJson(`https://circleci.com/api/v2/pipeline/${pipelineId}/workflow`)
-      .then(({ items }) => items.some(item => ((item.status === 'success') || (allowOnHoldWorkflow === 'true' && item.status === 'on_hold')) && item.name === workflowName));
+      .then(({ items }) => items.some(item => ((item.status === 'success') || (allowOnHoldWorkflow === '1' && item.status === 'on_hold')) && item.name === workflowName));
   }
 }
 


### PR DESCRIPTION
…r 1 in the script.

This pull request fixes a bug with the new param `allow-on-hold-workflow`. Because it is a boolean, in the script, it will have a value of `'0'` or '`1`'.

I did a simple test in a personal CircleCI workflow and verified param setting with the following:
```js
async function isWorkflowSuccessful(pipelineId, workflowName) {
  if (allowOnHoldWorkflow === '1') {
    console.log('Successfully set.');
  }
...
```

@meeroslav, question, I see that the script contains conditional `if (errorOnNoSuccessfulWorkflow === 'true') {`; has this been verified to work? I followed this example when creating `allowOnHoldWorkflow` as these two params are booleans. Let me know if we should change the `errorOnNoSuccessfulWorkflow` conditional to check if `=== '1'`.