### PR TITLE
[semver:patch] fix(scripts): build url regex for pipeline ids < 10

### DIFF
--- a/src/scripts/find-successful-workflow.js
+++ b/src/scripts/find-successful-workflow.js
@@ -10,7 +10,7 @@ const allowOnHoldWorkflow = process.argv[6] === '1';
 const workflowName = process.argv[7];
 const circleToken = process.env.CIRCLE_API_TOKEN;
 
-const [, host, project] = buildUrl.match(/https?:\/\/([^\/]+)\/(.*)\/\d./);
+const [, host, project] = buildUrl.match(/https?:\/\/([^\/]+)\/(.*)\/\d+/);
 
 let BASE_SHA;
 (async () => {


### PR DESCRIPTION
The current regex matched against the build url fails when the pipeline id is < 10. Fixed in this PR! I'm assuming the `.` isn't needed, but if it is we can adjust to `d+.`.