### PR TITLE
ci: new release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,75 +1,36 @@
 version: 2.1
-
+setup: true
 orbs:
-  nx: nrwl/nx@<<pipeline.parameters.dev-orb-version>>
-  orb-tools: circleci/orb-tools@10.0
+  orb-tools: circleci/orb-tools@11.1
+  shellcheck: circleci/shellcheck@3.1
 
-# Pipeline Parameters
-## These parameters are used internally by orb-tools. Skip to the Jobs section.
-parameters:
-  # These pipeline parameters are required by the "trigger-integration-tests-workflow"
-  # job, by default.
-  run-integration-tests:
-    type: boolean
-    default: false
-  dev-orb-version:
-    type: string
-    default: "dev:alpha"
-
-jobs:
-  set-shas-integration-test:
-    docker:
-      - image: cimg/node:14.17
-    steps:
-      - checkout
-      - nx/set-shas
+filters: &filters
+  tags:
+    only: /.*/
 
 workflows:
-  test-pack:
-    unless: << pipeline.parameters.run-integration-tests >>
+  lint-pack:
     jobs:
-      - orb-tools/lint
+      - orb-tools/lint:
+          filters: *filters
       - orb-tools/pack:
-          use-orb-pack: true
-      # Publish development version(s) of the orb.
-      - orb-tools/publish-dev:
+          filters: *filters
+      - orb-tools/review:
+          filters: *filters
+      - shellcheck/check:
+          exclude: SC2148,SC2038,SC2086,SC2002,SC2016
+          filters: *filters
+      - orb-tools/publish:
           orb-name: nrwl/nx
-          context: orb-publishing # A restricted context containing your private publishing credentials. Will only execute if approved by an authorized user.
+          vcs-type: << pipeline.project.type >>
           requires:
-            - orb-tools/lint
-            - orb-tools/pack
-      # Trigger an integration workflow to test the
-      # dev:${CIRCLE_SHA1:0:7} version of your orb
-      - orb-tools/trigger-integration-tests-workflow:
-          name: trigger-integration-dev
+            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
+          # Use a context to hold your publishing token.
           context: orb-publishing
-          requires:
-            - orb-tools/publish-dev
-
-  # This `integration-test_deploy` workflow will only run
-  # when the run-integration-tests pipeline parameter is set to true.
-  # It is meant to be triggered by the "trigger-integration-tests-workflow"
-  # job, and run tests on <your orb>@dev:${CIRCLE_SHA1:0:7}.
-  integration-test_deploy:
-    when: << pipeline.parameters.run-integration-tests >>
-    jobs:
-      # Run any integration tests defined within the `jobs` key.
-      - set-shas-integration-test
-      # Publish a semver version of the orb. relies on
-      # the commit subject containing the text "[semver:patch|minor|major|skip]"
-      # as that will determine whether a patch, minor or major
-      # version will be published or if publishing should
-      # be skipped.
-      # e.g. [semver:patch] will cause a patch version to be published.
-      - orb-tools/dev-promote-prod-from-commit-subject:
-          orb-name: nrwl/nx
-          context: orb-publishing
-          add-pr-comment: true
-          fail-if-semver-not-indicated: true
-          publish-version-tag: false
-          requires:
-            - set-shas-integration-test
-          filters:
-            branches:
-              only:
-                - main
+          filters: *filters
+      # Triggers the next workflow in the Orb Development Kit.
+      - orb-tools/continue:
+          pipeline-number: << pipeline.number >>
+          vcs-type: << pipeline.project.type >>
+          requires: [orb-tools/publish]
+          filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,0 +1,36 @@
+version: 2.1
+orbs:
+  nx: nrwl/nx@dev:<<pipeline.git.revision>>
+  orb-tools: circleci/orb-tools@11.1
+filters: &filters
+  tags:
+    only: /.*/
+jobs:
+  set-shas-integration-test:
+    docker:
+      - image: cimg/node:14.17
+    steps:
+      - checkout
+      - nx/set-shas
+workflows:
+  test-deploy:
+    jobs:
+      # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
+      - set-shas-integration-test:
+          filters: *filters
+      - orb-tools/pack:
+          filters: *filters
+      - orb-tools/publish:
+          orb-name: nrwl/nx
+          vcs-type: << pipeline.project.type >>
+          pub-type: production
+          requires:
+            - set-shas-integration-test
+            - orb-tools/pack
+            - command-tests
+          context: orb-publishing
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/


### PR DESCRIPTION
# Update the CI process

This change migrates the CI process to the new "[orb tools 11](https://github.com/CircleCI-Public/orb-tools-orb/releases/tag/v11.0.0)" process.

## Blocked By:
Enable "[dynamic configuration](https://circleci.com/docs/2.0/dynamic-config/#getting-started-with-dynamic-config-in-circleci)" for your project on CircleCI.
   - Visit https://app.circleci.com/ and navigate to your project.
   - Click _Project Settings_ in the upper right corner.
   - Click _Advanced_
   - Toggle on _Enable Dynamic Configuration_

## Notable changes:
- **Removed the 30 day limit**
  - Previously, the configuration relied on calling a `dev:alpha` tagged version of the orb for testing. Due to "dev" tags on CircleCI being ephemeral with a 30-day life span, if it had been over 30 days since the orb was last published this would result in an error in the CircleCI pipeline. Users would have to manually publish their orb locally to re-start the ci pipeline
  - The new dynamic configuration system allows us to publish the dev version of the orb _before_ calling it for testing. This means that the 30 day limit is no longer an issue.
- **Adopting Tag/Release based publishing**
  - Publishing previously required a special text flag to be added to the commit message and a new version was published on every merge to the main branch.
  - The new tag/release based publishing system will simply publish your orb when you opt to push a versioned tag or use GitHub's [releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) feature, which will create a tag and give you an opportunity to create a change log via [release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).
- **Review system**
  - The new "review" job can automatically detect opportunities to improve best-practices and provide native JUNIT output which will be displayed in the CircleCI UI.
  - Modeled after _shellcheck_, it is easy to skip any "review check" by supplying its "RC" code in the "exclude" parameter of the job.
- **Simplified/Improved PR Commenting**
  - Automatically comment on the PR associated with a commit when each new orb version is published (dev or production.)
  - The comment will include a link to the Orb Registry to preview dev versions of the orb, and a live link to the production version of the orb.

More information on deployments: https://circleci.com/docs/creating-orbs