### PR TITLE
fix: provide more info on private repos when missing access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+ - **[fix]**: Provide more information for private repos when missing access
 ## [1.6.1] - 2022-10-14
  - **[fix]**: Use fallback on CirclCI API glitches
  - **[fix]**: Fallback to main branch when CIRCLE_BRANCH is missing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.6.1] - 2022-10-14
  - **[fix]**: Use fallback on CirclCI API glitches
  - **[fix]**: Fallback to main branch when CIRCLE_BRANCH is missing
  - **[fix]**: Incorrect API page query param 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ width="100%" alt="Nx - Smart, Extensible Build Framework"></p>
 version: 2.1
 
 orbs:
-  nx: nrwl/nx@1.6.1
+  nx: nrwl/nx@1.6.2
 
 jobs:
   checks:

--- a/src/examples/custom.yml
+++ b/src/examples/custom.yml
@@ -8,7 +8,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    nx: nrwl/nx@1.6.1
+    nx: nrwl/nx@1.6.2
   jobs:
     build:
       docker:

--- a/src/examples/default.yml
+++ b/src/examples/default.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    nx: nrwl/nx@1.6.1
+    nx: nrwl/nx@1.6.2
   jobs:
     build:
       docker:

--- a/src/examples/private.yml
+++ b/src/examples/private.yml
@@ -7,4 +7,4 @@ description: >
 usage:
   version: 2.1
   orbs:
-    nx: nrwl/nx@1.6.1
+    nx: nrwl/nx@1.6.2

--- a/src/scripts/find-successful-workflow.js
+++ b/src/scripts/find-successful-workflow.js
@@ -135,8 +135,16 @@ async function getJson(url) {
 
       res.on('end', () => {
         const response = Buffer.concat(data).toString();
-        const responseJSON = JSON.parse(response);
-        resolve(responseJSON);
+        try {
+          const responseJSON = JSON.parse(response);
+          resolve(responseJSON);
+        } catch (e) {
+          if (response.includes('Project not found')) {
+            reject(new Error(`Error: Project not found.\nIf you are using a private repo, make sure the CIRCLE_API_TOKEN is set.\n\n${response}`));
+          } else {
+            reject(e)
+          }
+        }
       });
     }).on('error', error => reject(
       circleToken


### PR DESCRIPTION
Currently the error when repo cannot be accessed due to missing privileges is cryptic.

This PR adds a bit more context and a hint on what user can do to fix it.

Fixes #47