### PR TITLE
fix: delete generated script file

### DIFF
--- a/src/scripts/set-shas.sh
+++ b/src/scripts/set-shas.sh
@@ -20,3 +20,4 @@ echo "export NX_BASE=\"$BASE_SHA\";" >>$BASH_ENV
 echo "export NX_HEAD=\"$HEAD_SHA\";" >>$BASH_ENV
 echo ""
 echo "NX_BASE and NX_HEAD environment variables have been set for the current Job"
+rm index.js


### PR DESCRIPTION
Hey all,

This PR deletes the generated file created to run the node script. The file has been giving us problems in CI (with prettier checks for example), and I think it would be best to clean up after the Nx script is finished. ~I also parameterized it, figured gets us closer if there's a feature request in the future (happy to undo that though)~

In theory this is a patch-worthy change, but I'm curious if there's something I'm missing that might make this either an undesirable change or a breaking change.