### PR TITLE
fix: set BASE to undefined if HEAD~1 does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
  - **[fix]**: Provide more information for private repos when missing access
+ - **[fix]**: set BASE to undefined if HEAD~1 does not exist
+  
 ## [1.6.1] - 2022-10-14
  - **[fix]**: Use fallback on CirclCI API glitches
  - **[fix]**: Fallback to main branch when CIRCLE_BRANCH is missing


### PR DESCRIPTION
Update the BASE to be the empty git tree hash (the result of `git hash-object -t tree /dev/null` or `4b825dc642cb6eb9a060e54bf8d69288fbee4904`), in the case where HEAD~1 doesn't exist.